### PR TITLE
feat: remove special characters from group names

### DIFF
--- a/default.json
+++ b/default.json
@@ -15,8 +15,8 @@
   },
   "packageRules": [
     {
-      "description": "Automerge non-major updates and lockfile maintenance",
-      "groupName": "Non-major Updates and Lockfile Maintenance(auto merge)",
+      "description": "Automerge non-major updates",
+      "groupName": "Automerge Non-major Updates",
       "matchUpdateTypes": ["minor", "patch"],
       "automerge": true
     },

--- a/library.json
+++ b/library.json
@@ -14,7 +14,7 @@
   "packageRules": [
     {
       "description": "Automerge non-major updates",
-      "groupName": "Non-major Updates(auto merge)",
+      "groupName": "Automerge Non-major Updates",
       "matchUpdateTypes": ["minor", "patch"],
       "automerge": true
     }


### PR DESCRIPTION
The "(" and ")" characters in group names will be directly used in Renovate's branch names.

Although they are legal in git branch names, they are not convenient to use (e.g., copying the branch name into the shell).