### PR TITLE
feat: restrict ESLint version to v8

### DIFF
--- a/base-presets.json
+++ b/base-presets.json
@@ -6,6 +6,11 @@
       "matchSourceUrls": [
         "https://github.com/RightCapitalHQ/frontend-style-guide"
       ]
+    },
+    {
+      "description": "Restrict ESLint to v8",
+      "matchPackageNames": ["eslint"],
+      "allowedVersions": "<9.0.0"
     }
   ]
 }


### PR DESCRIPTION
We are not able to upgrade to ESLint v9 for now.

See: https://github.com/RightCapitalHQ/frontend-style-guide/issues/128