### PR TITLE
feat: enhance Renovate configuration

### DIFF
--- a/default.json
+++ b/default.json
@@ -17,6 +17,7 @@
     {
       "description": "Automerge non-major updates",
       "groupName": "Automerge Non-major Updates",
+      "matchCurrentVersion": "!/^0/",
       "matchUpdateTypes": ["minor", "patch"],
       "automerge": true
     },


### PR DESCRIPTION
Exclude major version zero (0.y.z) versions from non-major update groups.