### PR TITLE
feat: remove `maintainLockFilesWeekly` preset to avoid non-office hours notifications

### DIFF
--- a/base-presets.json
+++ b/base-presets.json
@@ -1,6 +1,11 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "minimumReleaseAge": "7 days",
+  "lockFileMaintenance": {
+    "enabled": true,
+    "automerge": true,
+    "schedule": ["* 9-10 * * 1"]
+  },
   "packageRules": [
     {
       "matchPackageNames": ["@rightcapital/*"],

--- a/default.json
+++ b/default.json
@@ -5,7 +5,6 @@
   "extends": [
     "config:recommended",
     ":pinAllExceptPeerDependencies",
-    ":maintainLockFilesWeekly",
     "docker:pinDigests",
     "github>RightCapitalHQ/renovate-config:base-presets"
   ],
@@ -18,10 +17,6 @@
       "description": "Automerge non-major updates",
       "groupName": "Automerge Non-major Updates",
       "extends": [":automergeStableNonMajor"]
-    },
-    {
-      "matchUpdateTypes": ["lockFileMaintenance"],
-      "automerge": true
     }
   ],
   "platformAutomerge": true,

--- a/library.json
+++ b/library.json
@@ -5,7 +5,6 @@
   "extends": [
     "config:recommended",
     ":pinAllExceptPeerDependencies",
-    ":maintainLockFilesWeekly",
     "docker:pinDigests",
     "github>RightCapitalHQ/renovate-config:base-presets"
   ],


### PR DESCRIPTION
## Problem
The inherited preset config `maintainLockFilesWeekly` has a default schedule that runs during early morning hours, causing notifications to be sent during non-office hours.

## Solution
- Remove the `maintainLockFilesWeekly` preset configuration
- Implement custom scheduling rules that run during business hours
