### PR TITLE
feat: ignore rc-actions-bot commits in branch modification check

### DIFF
--- a/base-presets.json
+++ b/base-presets.json
@@ -2,6 +2,9 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "internalChecksFilter": "strict",
   "minimumReleaseAge": "7 days",
+  "gitIgnoredAuthors": [
+    "270908863+rc-actions-bot[bot]@users.noreply.github.com"
+  ],
   "lockFileMaintenance": {
     "enabled": true,
     "automerge": true,


### PR DESCRIPTION
Add `gitIgnoredAuthors` so Renovate does not treat commits made by `rc-actions-bot[bot]` as user-modifications.

## Why

Our reusable workflows (e.g. `nx-release-auto-plan`) amend Renovate's HEAD commit to attach an auto-generated Nx version plan and force-push back with `--force-with-lease`. With recent Renovate versions, the branch-modification check is stricter: if the branch tip does not match what Renovate expects to generate, Renovate force-resets the branch — which then triggers our workflow to amend again — a force-push loop between the two bots.

Example: https://github.com/RightCapitalHQ/frontend-style-guide/pull/380 spent a full day in this loop (30+ workflow runs).

Listing the bot identity here lets Renovate know it can safely rebase through these commits (and stop fighting them).

## Bot identity

GitHub App: https://github.com/apps/rc-actions-bot
- User id: \`270908863\`
- Email used in commits: \`270908863+rc-actions-bot[bot]@users.noreply.github.com\`

## Related

- App-side change: configure the same identity in \`RightCapitalHQ/actions\` \`nx-release-auto-plan\`