### PR TITLE
feat: add customManager for RightCapitalHQ/actions reusable workflow refs

### DIFF
--- a/base-presets.json
+++ b/base-presets.json
@@ -29,5 +29,19 @@
       "groupName": "Strip.js packages",
       "matchPackageNames": ["@stripe/stripe-js", "@stripe/react-stripe-js"]
     }
+  ],
+  "customManagers": [
+    {
+      "customType": "regex",
+      "description": "Update RightCapitalHQ/actions reusable workflow refs, scoped to per-action tag prefix (e.g. nx-release-auto-plan/v1.2.3)",
+      "managerFilePatterns": ["/(^|/)\\.github/workflows/[^/]+\\.ya?ml$/"],
+      "matchStrings": [
+        "uses:\\s*(?:RightCapitalHQ|rightcapitalhq)/actions/\\.github/workflows/[^@\\s]+@(?<currentValue>(?<prefix>[a-z-]+)/v\\d+\\.\\d+\\.\\d+)"
+      ],
+      "depNameTemplate": "RightCapitalHQ/actions",
+      "packageNameTemplate": "RightCapitalHQ/actions",
+      "datasourceTemplate": "github-tags",
+      "versioningTemplate": "regex:^{{{prefix}}}/v(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)$"
+    }
   ]
 }


### PR DESCRIPTION
## Why

Renovate's built-in `github-actions` manager can't follow our per-action tag scheme (`<project>/vX.Y.Z` published in the shared `RightCapitalHQ/actions` repo) for cross-repo reusable workflows. Every `uses:` line resolves to the same `RightCapitalHQ/actions` repo, but the three actions in there (`nx-release`, `nx-release-pr`, `nx-release-auto-plan`) each have their own tag stream and need to be tracked independently. As a result, the relevant ref bumps in consumer repos have always required manual PRs.

You can see this in [`frontend-style-guide` ci.yml history](https://github.com/RightCapitalHQ/frontend-style-guide/commits/main/.github/workflows/ci.yml): all `actions/checkout` / `pnpm/action-setup` / `rhysd/actionlint` bumps come from `renovate[bot]`, while every `ci: update shared nx-release actions to v0.4.x` is a hand-written commit.

## What

Add a `customManager` that:

- Matches `uses: RightCapitalHQ/actions/.github/workflows/<file>.yml@<prefix>/vX.Y.Z` lines in any workflow file
- Captures the tag prefix into a per-prefix `regex:` versioning, so each action's tag series is tracked independently (no cross-talk between `nx-release-auto-plan/v*` and `nx-release-pr/v*`)
- Uses the `github-tags` datasource against `RightCapitalHQ/actions`

Now Renovate can own these bumps end-to-end. Pairs with the just-merged `gitIgnoredAuthors` entry for `rc-actions-bot[bot]`, so the resulting PRs won't fight `nx-release-auto-plan`'s amend either.

## Validation

```
pnpm exec renovate-config-validator --strict base-presets.json default.json library.json
# INFO: Config validated successfully
```

Refs: #277, https://github.com/RightCapitalHQ/frontend-style-guide/pull/380