### PR TITLE
fix: route RightCapitalHQ/actions reusable workflow refs only through customManager

### DIFF
--- a/base-presets.json
+++ b/base-presets.json
@@ -28,6 +28,12 @@
     {
       "groupName": "Strip.js packages",
       "matchPackageNames": ["@stripe/stripe-js", "@stripe/react-stripe-js"]
+    },
+    {
+      "description": "Disable the built-in github-actions manager for RightCapitalHQ/actions reusable workflows. Their tags are prefix-first (e.g. nx-release-auto-plan/v1.2.3), which fails Renovate's `/^v?\\d+/` check and routes to the github-digest datasource (digest-pinning only, no version updates). The customManager below handles them instead.",
+      "matchManagers": ["github-actions"],
+      "matchPackageNames": ["RightCapitalHQ/actions"],
+      "enabled": false
     }
   ],
   "customManagers": [
@@ -38,7 +44,7 @@
       "matchStrings": [
         "uses:\\s*(?:RightCapitalHQ|rightcapitalhq)/actions/\\.github/workflows/[^@\\s]+@(?<currentValue>(?<prefix>[a-z-]+)/v\\d+\\.\\d+\\.\\d+)"
       ],
-      "depNameTemplate": "RightCapitalHQ/actions",
+      "depNameTemplate": "RightCapitalHQ/actions/{{prefix}}",
       "packageNameTemplate": "RightCapitalHQ/actions",
       "datasourceTemplate": "github-tags",
       "versioningTemplate": "regex:^{{{prefix}}}/v(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)$"


### PR DESCRIPTION
## What the logs showed

```json
{
  "depName": "RightCapitalHQ/actions",
  "depType": "action",
  "datasource": "github-digest",
  "versioning": "exact",
  "currentValue": "nx-release-auto-plan/v0.4.1",
  "updates": []
}
```

`depType: "action"` + `datasource: "github-digest"` ⇒ this is the **built-in** `github-actions` manager, not the customManager added in #278.

## Why digest, not tags

The built-in github-actions manager [routes by ref string](https://docs.renovatebot.com/modules/manager/github-actions/#non-semver-refs-branches-and-feature-tags): if the ref does **not** match `/^v?\d+/`, it falls back to `github-digest` (digest-pinning only, never proposes version bumps). Our refs start with `nx-release-auto-plan/...`, which fails that check — so version updates can never happen via the built-in path. The "slash is also a valid separator" docs section refers to in-`github-tags` tag parsing, not the routing decision.

Meanwhile, our customManager extraction collided on the same `depName: RightCapitalHQ/actions` and got de-duped out.

## Fix

1. Add a `packageRule` that disables the `github-actions` manager specifically for `RightCapitalHQ/actions`, so the built-in extraction is dropped.
2. Make the customManager's `depName` include the tag prefix → `RightCapitalHQ/actions/<prefix>`. This:
   - removes any ambiguity with the disabled built-in entry,
   - surfaces the three actions (`nx-release`, `nx-release-pr`, `nx-release-auto-plan`) as distinct deps in the Dependency Dashboard and PR titles.

`packageNameTemplate` stays `RightCapitalHQ/actions` so the `github-tags` datasource lookup still hits the right repo.

## Validation

```
pnpm exec renovate-config-validator --strict base-presets.json default.json library.json
# INFO: Config validated successfully
```

Refs: #278, https://github.com/RightCapitalHQ/frontend-style-guide/pull/380