### PR TITLE
feat: dedicated group + no release-age cooldown for RightCapitalHQ/actions

### DIFF
--- a/base-presets.json
+++ b/base-presets.json
@@ -34,6 +34,12 @@
       "matchManagers": ["github-actions"],
       "matchPackageNames": ["RightCapitalHQ/actions"],
       "enabled": false
+    },
+    {
+      "description": "Group RightCapitalHQ/actions reusable workflow refs and skip release-age cooldown (we own them)",
+      "matchPackageNames": ["RightCapitalHQ/actions/**"],
+      "groupName": "RightCapital actions",
+      "minimumReleaseAge": null
     }
   ],
   "customManagers": [


### PR DESCRIPTION
Mirror the existing `@rightcapital/*` carve-out for our own GitHub Actions repo.

## Changes

```jsonc
{
  "description": "Group RightCapitalHQ/actions reusable workflow refs and skip release-age cooldown (we own them)",
  "matchPackageNames": ["RightCapitalHQ/actions/**"],
  "groupName": "RightCapital actions",
  "minimumReleaseAge": null
}
```

- `minimumReleaseAge: null` — disables the 7-day cooldown. The cooldown protects against compromised upstream packages, which does not apply to a repo we maintain.
- `groupName: "RightCapital actions"` — keeps the three deps (`RightCapitalHQ/actions/nx-release`, `.../nx-release-pr`, `.../nx-release-auto-plan`) out of the general "Non-Major Dependencies" PR so they ship as a single focused PR.

## Glob

`RightCapitalHQ/actions/**` matches the customManager's `depNameTemplate: "RightCapitalHQ/actions/{{prefix}}"` output for all three (and any future) actions in the repo.

## Validation

```
pnpm exec renovate-config-validator --strict base-presets.json default.json library.json
# INFO: Config validated successfully
```

Refs: #279, https://github.com/RightCapitalHQ/frontend-style-guide/pull/380