### PR TITLE
fix: match RightCapitalHQ/actions deps by depName, not packageName

### DIFF
--- a/base-presets.json
+++ b/base-presets.json
@@ -36,8 +36,8 @@
       "enabled": false
     },
     {
-      "description": "Group RightCapitalHQ/actions reusable workflow refs and skip release-age cooldown (we own them)",
-      "matchPackageNames": ["RightCapitalHQ/actions/**"],
+      "description": "Group RightCapitalHQ/actions reusable workflow refs and skip release-age cooldown (we own them). Match by depName because the customManager sets a per-prefix depName (`RightCapitalHQ/actions/<action>`) while packageName stays the bare repo for the github-tags lookup.",
+      "matchDepNames": ["RightCapitalHQ/actions/**"],
       "groupName": "RightCapital actions",
       "minimumReleaseAge": null
     }


### PR DESCRIPTION
## Observation

After #280 merged, the next Renovate run still landed all three RC actions in `renovate/non-major-dependencies`, and `v0.5.0` stayed in `pendingVersions`:

```json
{
  "depName": "RightCapitalHQ/actions/nx-release",
  "packageName": "RightCapitalHQ/actions",
  "newValue": "nx-release/v0.4.2",
  "pendingVersions": ["nx-release/v0.5.0"],
  "branchName": "renovate/non-major-dependencies"
}
```

So neither `groupName: "RightCapital actions"` nor `minimumReleaseAge: null` applied.

## Why

`matchPackageNames` matches against `packageName` first (only falling back to `depName` when `packageName` is unset). Our customManager sets:

- `depName` → `RightCapitalHQ/actions/<prefix>` (per-action)
- `packageName` → `RightCapitalHQ/actions` (bare repo, required for the `github-tags` lookup)

So `RightCapitalHQ/actions/**` never matched `RightCapitalHQ/actions`.

## Fix

Switch to `matchDepNames`, which is the per-action string and includes the prefix segment.

The neighbouring `matchPackageNames: ["RightCapitalHQ/actions"]` rule (disable built-in github-actions manager) still works as-is, since it's an exact match on `packageName`.

## Validation

```
pnpm exec renovate-config-validator --strict base-presets.json default.json library.json
# INFO: Config validated successfully
```

Refs: #280, https://github.com/RightCapitalHQ/frontend-style-guide/pull/380