### PR TITLE
Migrate Renovate presets to best practices

### DIFF
--- a/base-presets.json
+++ b/base-presets.json
@@ -12,6 +12,16 @@
   },
   "packageRules": [
     {
+      "description": "Override security:minimumReleaseAgeNpm's 3-day default back to the shared 7-day cooldown.",
+      "matchDatasources": ["npm"],
+      "minimumReleaseAge": "7 days"
+    },
+    {
+      "description": "Do not require minimum release age for lock file maintenance.",
+      "matchUpdateTypes": ["lockFileMaintenance"],
+      "minimumReleaseAge": null
+    },
+    {
       "matchPackageNames": ["@rightcapital/*"],
       "minimumReleaseAge": null
     },

--- a/default.json
+++ b/default.json
@@ -3,9 +3,8 @@
   "automergeType": "pr",
   "description": "App-specific config for RightCapital repositories",
   "extends": [
-    "config:recommended",
+    "config:best-practices",
     ":pinAllExceptPeerDependencies",
-    "docker:pinDigests",
     "github>RightCapitalHQ/renovate-config:base-presets"
   ],
   "labels": ["renovate"],

--- a/library.json
+++ b/library.json
@@ -3,9 +3,8 @@
   "automergeType": "pr",
   "description": "Library-specific config for RightCapital repositories",
   "extends": [
-    "config:recommended",
+    "config:best-practices",
     ":pinAllExceptPeerDependencies",
-    "docker:pinDigests",
     "github>RightCapitalHQ/renovate-config:base-presets"
   ],
   "labels": ["renovate"],


### PR DESCRIPTION
## Summary
- migrate exposed Renovate presets from config:recommended to config:best-practices
- remove redundant docker:pinDigests extension now covered by config:best-practices
- keep the shared top-level 7-day release-age cooldown
- override security:minimumReleaseAgeNpm's package rule back to the shared 7-day npm cooldown
- exempt lockFileMaintenance updates from the release-age cooldown

## Validation
- pnpm run lint
- pnpm run test
- pnpm exec renovate-config-validator --strict base-presets.json
- git diff --check